### PR TITLE
Limit Category Selections

### DIFF
--- a/webli_forums/blocks/webli_forum_post/controller.php
+++ b/webli_forums/blocks/webli_forum_post/controller.php
@@ -2,6 +2,7 @@
 namespace Concrete\Package\WebliForums\Block\WebliForumPost;
 use Loader;
 use Core;
+use Database;
 use Page;
 use Concrete\Core\Page\PageList;
 use PageTemplate;
@@ -70,7 +71,7 @@ class Controller extends BlockController
 		$publicForums = array();
 		
 		// get array of values in db
-		$db = Loader::db();
+		$db = Database::connection();
 		
 		$res = $db->GetAll("select * from btWebliForums where anonymous_posts = ?", 1);
 	
@@ -105,7 +106,7 @@ class Controller extends BlockController
 	function get_saved_settings()
 	{
 		// get array of values in db
-		$db = Loader::db();
+		$db = Database::connection();
 		
 		$res = $db->GetRow("select * from btWebliForums where cID = ?", Page::getCurrentPage()->getCollectionParentID());
 		
@@ -141,7 +142,7 @@ class Controller extends BlockController
 	
 	function action_new_forum_post()
 	{
-		$vf = Loader::helper('validation/form');
+		$vf = Core::make('helper/validation/form');
         $vf->setData($_POST['ccm_token']);
         $vf->addRequiredToken('new_forum_post');
         
@@ -179,7 +180,7 @@ class Controller extends BlockController
 			if($_POST['forumTags']) $newPage->setAttribute('forum_tags', $_POST['forumTags'] );
 			
 			// get moderator approval attribute for blog category
-			$db = Loader::db();
+			$db = Database::connection();
 			$res = $db->GetRow("select * from btWebliForums where cID = ?", $_POST['forumSelect']);
 			
 			if($res['mod_approval']){
@@ -216,7 +217,7 @@ class Controller extends BlockController
 	
 		function action_edit_forum_post()
 	{
-		$vf = Loader::helper('validation/form');
+		$vf = Core::make('helper/validation/form');
         $vf->setData($_POST['ccm_token']);
         $vf->addRequiredToken('edit_forum_post');
         
@@ -282,7 +283,7 @@ class Controller extends BlockController
 
 	function action_set_pin()
 	{		
-		$vf = Loader::helper('validation/form');
+		$vf = Core::make('helper/validation/form');
         $vf->setData($_POST['ccm_token']);
         $vf->addRequiredToken('set_pin');
         
@@ -298,7 +299,7 @@ class Controller extends BlockController
 	
 	function action_set_unpin()
 	{	
-		$vf = Loader::helper('validation/form');
+		$vf = Core::make('helper/validation/form');
         $vf->setData($_POST['ccm_token']);
         $vf->addRequiredToken('set_unpin');
         
@@ -315,7 +316,7 @@ class Controller extends BlockController
 	{
 		$cp = new Permissions(Page::getCurrentPage());
 
-		$vf = Loader::helper('validation/form');
+		$vf = Core::make('helper/validation/form');
         $vf->setData($_POST['ccm_token']);
         $vf->addRequiredToken('delete_page');
         
@@ -335,7 +336,7 @@ class Controller extends BlockController
 	
 	function action_approve_page()
 	{
-		$vf = Loader::helper('validation/form');
+		$vf = Core::make('helper/validation/form');
         $vf->setData($_POST['ccm_token']);
         $vf->addRequiredToken('approve_page');
         
@@ -351,7 +352,7 @@ class Controller extends BlockController
 
 	function action_unapprove_page()
 	{
-		$vf = Loader::helper('validation/form');
+		$vf = Core::make('helper/validation/form');
         $vf->setData($_POST['ccm_token']);
         $vf->addRequiredToken('unapprove_page');
         

--- a/webli_forums/blocks/webli_forum_post/controller.php
+++ b/webli_forums/blocks/webli_forum_post/controller.php
@@ -131,8 +131,19 @@ class Controller extends BlockController
 	
 	function get_forum_pages()
 	{
+        $c = Page::getCurrentPage();
+        if ($c->getPageTypeName() == 'forum_post')
+        {
+            $parentCID = $c->getCollectionParentID();
+        }
+        else
+        {
+            $parentCID = $c->getCollectionID();
+        }
+        if ($parentCID < 1 || $parentCID == false) $parentCID = 1;
 		$fpl = new PageList();
 		$fpl->sortByDisplayOrder();
+		$fpl->filterByParentID($parentCID);
 		$fpl->filterByAttribute('forum_category', true);
 		$forumPages = $fpl->get();
 		

--- a/webli_forums/blocks/webli_forum_post/view.php
+++ b/webli_forums/blocks/webli_forum_post/view.php
@@ -1,10 +1,10 @@
 <?php  defined('C5_EXECUTE') or die("Access Denied.");
-$al = Loader::helper('concrete/asset_library');
+$al = Core::make('helper/concrete/asset_library');
 $fp = FilePermissions::getGlobal();
 $tp = new TaskPermission();
 $u = new User();
-$form = Loader::helper('form');
-$nav = Loader::helper("navigation");
+$form = Core::make('helper/form');
+$nav = Core::make('helper/navigation');
 $th = Core::make('helper/text');
 if(!$forumAdmin) { ?>
 


### PR DESCRIPTION
I would like to propose this function to limit the selection of available category from the forum posts.

If you have a lot of categories, it would be a long pull-down menu.
So you may want to limit that.

I made this modification really quickly for my site.
But we could add an option to Forum Post block by adding checkbox like `Limit the categories to the current page's site tree` Or something.

And the Forum Post block in Forum Post page template should be turned on for this option.

What do you think?