### PR TITLE
Plain Text mode doesn’t respect line break.

### DIFF
--- a/webli_forums/page_templates/forum_post.php
+++ b/webli_forums/page_templates/forum_post.php
@@ -103,7 +103,7 @@ if($display['add_this'] && $display['add_this_script']) echo $display['add_this_
                             }
                             else
                             {
-                                echo nl2br(h($c->getCollectionAttributeValue('forum_post'));
+                                echo nl2br(h($c->getCollectionAttributeValue('forum_post')));
                             }
                             ?>
 							<div style="clear:both"></div>

--- a/webli_forums/page_templates/forum_post.php
+++ b/webli_forums/page_templates/forum_post.php
@@ -96,8 +96,16 @@ if($display['add_this'] && $display['add_this_script']) echo $display['add_this_
 								$u = new user();
 								$usr = UserInfo::getByID($c->getCollectionUserID());
 								print Loader::helper('concrete/avatar')->outputUserAvatar($usr);
-							endif; ?>
-							<?php echo $c->getCollectionAttributeValue('forum_post') ?>
+							endif;
+    						if($display['rich_text'])
+    						{
+    						    echo $c->getCollectionAttributeValue('forum_post');
+                            }
+                            else
+                            {
+                                echo nl2br(h($c->getCollectionAttributeValue('forum_post'));
+                            }
+                            ?>
 							<div style="clear:both"></div>
 						</div>
 						


### PR DESCRIPTION
When I disable the Rich Text Editor mode, the link break on textarea didn't respect the setting.