### PR TITLE
Posting script should be located under elements

### DIFF
--- a/webli_forums/blocks/webli_forum_post/controller.php
+++ b/webli_forums/blocks/webli_forum_post/controller.php
@@ -132,20 +132,21 @@ class Controller extends BlockController
 	function get_forum_pages()
 	{
         $c = Page::getCurrentPage();
-        if ($c->getPageTypeName() == 'forum_post')
+        if ($c->getPageTypeHandle() == 'forum_post') //Need to change
         {
             $parentCID = $c->getCollectionParentID();
+            $forumPages = array(Page::getByID($parentCID));
         }
         else
         {
             $parentCID = $c->getCollectionID();
+            if ($parentCID < 1 || $parentCID == false) $parentCID = 1;
+    		$fpl = new PageList();
+    		$fpl->sortByDisplayOrder();
+    		$fpl->filterByParentID($parentCID);
+    		$fpl->filterByAttribute('forum_category', true);
+    		$forumPages = $fpl->get();
         }
-        if ($parentCID < 1 || $parentCID == false) $parentCID = 1;
-		$fpl = new PageList();
-		$fpl->sortByDisplayOrder();
-		$fpl->filterByParentID($parentCID);
-		$fpl->filterByAttribute('forum_category', true);
-		$forumPages = $fpl->get();
 		
 		return $forumPages;
 	}


### PR DESCRIPTION
I had an occasion that need to change the text label ot forum post block.

I thought I would create the custom template.

But I realize that webli_forum_post/view.php include the form to add or edit the post.
It would be troublesome to fix the entry form if I create additional custom template.

I think you should separate the forum entry form and store it under elements folder.

If you like it, I can start working on it.