### PR TITLE
Making getIndexedSearchTable() non-static calls

### DIFF
--- a/webli_forums/blocks/webli_forum_archive/controller.php
+++ b/webli_forums/blocks/webli_forum_archive/controller.php
@@ -81,7 +81,8 @@ class Controller extends BlockController
         }
 
         $db = Database::connection();
-        $columns = $db->MetaColumnNames(CollectionAttributeKey::getDefaultIndexedSearchTable());
+        $collectionAttributeKey = new CollectionAttributeKey();
+        $columns = $db->MetaColumnNames($collectionAttributeKey->getIndexedSearchTable());
         if (in_array('ak_exclude_page_list', $columns)) {
             $this->list->filter(false, '(ak_exclude_page_list = 0 or ak_exclude_page_list is null)');
         }

--- a/webli_forums/blocks/webli_forum_list/controller.php
+++ b/webli_forums/blocks/webli_forum_list/controller.php
@@ -114,7 +114,7 @@ class Controller extends BlockController
         }
 
         $db = Database::connection();
-        if function_exists(CollectionAttributeKey::getDefaultIndexedSearchTable())
+        if (function_exists(CollectionAttributeKey::getDefaultIndexedSearchTable()))
         {
             $columns = $db->MetaColumnNames(CollectionAttributeKey::getDefaultIndexedSearchTable());
         } else

--- a/webli_forums/blocks/webli_forum_list/controller.php
+++ b/webli_forums/blocks/webli_forum_list/controller.php
@@ -115,13 +115,7 @@ class Controller extends BlockController
 
         $db = Database::connection();
         $collectionAttributeKey = new CollectionAttributeKey();
-        if (method_exists($collectionAttributeKey, 'getDefaultIndexedSearchTable'))
-        {
-            $columns = $db->MetaColumnNames(CollectionAttributeKey::getDefaultIndexedSearchTable());
-        } else
-        {
-            $columns = $db->MetaColumnNames(CollectionAttributeKey::getIndexedSearchTable());
-        }
+        $columns = $db->MetaColumnNames($collectionAttributeKey->getIndexedSearchTable());
         if (in_array('ak_exclude_page_list', $columns)) {
             $this->list->filter(false, '(ak_exclude_page_list = 0 or ak_exclude_page_list is null)');
         }

--- a/webli_forums/blocks/webli_forum_list/controller.php
+++ b/webli_forums/blocks/webli_forum_list/controller.php
@@ -114,7 +114,8 @@ class Controller extends BlockController
         }
 
         $db = Database::connection();
-        if (function_exists(CollectionAttributeKey::getDefaultIndexedSearchTable()))
+        $collectionAttributeKey = new CollectionAttributeKey();
+        if (method_exists($collectionAttributeKey, 'getDefaultIndexedSearchTable'))
         {
             $columns = $db->MetaColumnNames(CollectionAttributeKey::getDefaultIndexedSearchTable());
         } else

--- a/webli_forums/blocks/webli_forum_list/controller.php
+++ b/webli_forums/blocks/webli_forum_list/controller.php
@@ -114,7 +114,13 @@ class Controller extends BlockController
         }
 
         $db = Database::connection();
-        $columns = $db->MetaColumnNames(CollectionAttributeKey::getDefaultIndexedSearchTable());
+        if function_exists(CollectionAttributeKey::getDefaultIndexedSearchTable())
+        {
+            $columns = $db->MetaColumnNames(CollectionAttributeKey::getDefaultIndexedSearchTable());
+        } else
+        {
+            $columns = $db->MetaColumnNames(CollectionAttributeKey::getIndexedSearchTable());
+        }
         if (in_array('ak_exclude_page_list', $columns)) {
             $this->list->filter(false, '(ak_exclude_page_list = 0 or ak_exclude_page_list is null)');
         }


### PR DESCRIPTION
Additional fix of #26, this is much smarter way to fix. But if you decided not to care pre-5.7.5.4, then you don't need to merge this PR.

I just wanted to let you know that there is a solution to support 5.7.5.3 and earlier version.

REF
https://www.concrete5.org/marketplace/addons/page-list/support/5.7.5.4-may-break-pl/#796174